### PR TITLE
do_git_checkout modified to checkout master or main for opus

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -432,7 +432,15 @@ do_git_checkout() {
   # reset will be useless if they didn't git_get_latest but pretty fast so who cares...plus what if they changed branches? :)
   old_git_version=`git rev-parse HEAD`
   if [[ -z $desired_branch ]]; then
-    desired_branch="origin/master"
+	# Check for either "origin/main" or "origin/master".
+	if [ $(git show-ref | grep -e origin\/main$ -c) = 1 ]; then
+		desired_branch="origin/main"
+	elif [ $(git show-ref | grep -e origin\/master$ -c) = 1 ]; then
+		desired_branch="origin/master"
+	else
+		echo "No valid git branch!"
+		exit 1
+	fi
   fi
   echo "doing git checkout $desired_branch"
   git -c 'advice.detachedHead=false' checkout "$desired_branch" || (git_hard_reset && git -c 'advice.detachedHead=false' checkout "$desired_branch") || (git reset --hard "$desired_branch") || exit 1 # can't just use merge -f because might "think" patch files already applied when their changes have been lost, etc...


### PR DESCRIPTION
Hello,
I encountered while building opus no origin/master branch error.
I found a solution to checkout origin/main, and more neat solution is found in https://github.com/rdp/ffmpeg-windows-build-helpers/issues/731#issuecomment-2021271889.
I am creating a pull request applied this solution.
Please consider this.
Thank you always.